### PR TITLE
Makefile: add 'submodules' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ push:
 	echo
 endif
 
+submodules:
+	git submodule update --init --recursive
+
 build:
 	docker build -t $(TAG) .
 


### PR DESCRIPTION
The proposed change aims to make submodule updates in 'vmctl' quicker and more simple.

### Proposed Solution

After:
```diff
git clone ...
cd vmctl
ls {demo,ci}
# (empty response)
```
Before:
```diff
git clone ...
cd vmctl
+ make submodules 
ls {demo,ci}
# (expected response after successful submodule initialization)
```